### PR TITLE
fix: ID parsing logic in PEG grammar fix, and enhance vertex unit tes…

### DIFF
--- a/nodejs/pegjs/agens.pegjs
+++ b/nodejs/pegjs/agens.pegjs
@@ -45,7 +45,7 @@ _Edge = label:Id "[" id:GraphId "]" "[" from:GraphId "," to:GraphId  "]" props:O
 
 _Path = "[" _Vertex "," _Edge "," _Vertex ("," _Edge "," _Vertex)* "]"  {  return mkPath(); }
 
-Id = ([_\$D][_\$w]*) { return text(); }
+Id = (![\[\]{}(),:. \t\n\r] .)+ { return text(); }
 
 GraphId = graphid:Number { return num2GraphId(text());}
 

--- a/nodejs/test/unit/vertexUnitTest.js
+++ b/nodejs/test/unit/vertexUnitTest.js
@@ -7,6 +7,10 @@ describe('VertexUnitTest suite', function () {
 
     const vertex = agens.parse('v[7.9]{"s": "", "i": 0, "b": false, "a": [], "o": {}}', {startRule: '_Vertex'});
     const koreanVertex = agens.parse('한국어[11.1]{"s": "", "i": 0, "b": false, "a": [], "o": {}}', {startRule: '_Vertex'});
+    const chineseVertex = agens.parse('中文[11.2]{"s": "", "i": 0, "b": false, "a": [], "o": {}}', {startRule: '_Vertex'});
+    const hiraganaVertex = agens.parse('ひらがな[11.3]{"s": "", "i": 0, "b": false, "a": [], "o": {}}', {startRule: '_Vertex'});
+    const katakanaVertex = agens.parse('カタカナ[11.4]{"s": "", "i": 0, "b": false, "a": [], "o": {}}', {startRule: '_Vertex'});
+    const arabicVertex = agens.parse('العربية[11.5]{"s": "", "i": 0, "b": false, "a": [], "o": {}}', {startRule: '_Vertex'});
 
     it('Test Label', function (done) {
         assert.strictEqual(vertex.label, 'v');
@@ -20,6 +24,31 @@ describe('VertexUnitTest suite', function () {
 
     it('Test Vetex ID (for Korean characters label node)', function (done) {
         assert.deepStrictEqual(koreanVertex.id, new g.GraphId(11, 1));
+        done();
+    })
+
+    it('Test Vetex ID (for Chinese characters label node)', function (done) {
+        assert.deepStrictEqual(chineseVertex.id, new g.GraphId(11, 2));
+        done();
+    })
+
+    it('Test Vetex ID (for Hiragana characters label node)', function (done) {
+        assert.deepStrictEqual(hiraganaVertex.id, new g.GraphId(11, 3));
+        done();
+    })
+
+    it('Test Vetex ID (for Katakana characters label node)', function (done) {
+        assert.deepStrictEqual(katakanaVertex.id, new g.GraphId(11, 4));
+        done();
+    })
+
+    it('Test Vetex ID (for Arabic characters label node)', function (done) {
+        assert.deepStrictEqual(arabicVertex.id, new g.GraphId(11, 5));
+        done();
+    })
+
+    it('Test Vetex ID (for Arabic characters label node)', function (done) {
+        assert.deepStrictEqual(arabicVertex.id, new g.GraphId(11, 5));
         done();
     })
 


### PR DESCRIPTION
The syntax error was caused by an incorrect identifier pattern in the PEG.js grammar file 
Problem: The original Id rule was defined as:
```
Id = ([_\$D][_\$w]*) { return text(); }
```

This pattern [_\$D] was interpreted as a character class containing only the literal characters _, $, and D, which is why it failed when trying to parse identifiers like e1, e2, e3 that start with e.

i fixed it:
```
Id = (![\[\]{}(),:. \t\n\r] .)+ { return text(); }
```

This new pattern matches any sequence of characters that are NOT special delimiters (brackets, braces, parentheses, commas, colons, periods, or whitespace), which allows for flexible identifier naming including
39 tests now pass successfully.